### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/dinvestaai/9b1c6dc1-a806-443a-a6fd-e291698a6403/a14a5a0f-b4f8-49f2-8bec-f2cc42f46b15/_apis/work/boardbadge/6961939b-616f-463f-8383-87be65381331)](https://dev.azure.com/dinvestaai/9b1c6dc1-a806-443a-a6fd-e291698a6403/_boards/board/t/a14a5a0f-b4f8-49f2-8bec-f2cc42f46b15/Microsoft.RequirementCategory)
 # dbrentacar


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/dinvestaai/9b1c6dc1-a806-443a-a6fd-e291698a6403/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.